### PR TITLE
use custom close button

### DIFF
--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -41,8 +41,8 @@ export const IFrameHelper = {
     addClass(widgetHolder, holderClassName);
 
     let closeBtn = document.createElement('button');
-    closeBtn.id = 'closeBtn';
-    closeBtn.onclick = window.$chatwoot.toggle;
+    closeBtn.id = 'chatwoot_close_btn';
+    closeBtn.onclick = onBubbleClick;
     addClass(closeBtn, 'button close-btn');
     closeBtn.style.visibility = 'hidden';
 
@@ -175,7 +175,7 @@ export const IFrameHelper = {
     iframe.style.visibility = '';
     iframe.setAttribute('id', `chatwoot_live_chat_widget`);
 
-    const closeBtn = document.getElementById('closeBtn');
+    const closeBtn = document.getElementById('chatwoot_close_btn');
     closeBtn.style.visibility = '';
 
     loadCSS();

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -43,7 +43,7 @@ export const IFrameHelper = {
     let closeBtn = document.createElement('button');
     closeBtn.id = 'closeBtn';
     closeBtn.onclick = window.$chatwoot.toggle;
-    addClass(closeBtn, 'button transparent compact close-button close-btn');
+    addClass(closeBtn, 'button close-btn');
     closeBtn.style.visibility = 'hidden';
 
     widgetHolder.appendChild(closeBtn);

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -39,6 +39,15 @@ export const IFrameHelper = {
       holderClassName += ` woot-widget--without-bubble`;
     }
     addClass(widgetHolder, holderClassName);
+
+    let closeBtn = document.createElement('button');
+    closeBtn.id = 'closeBtn';
+    closeBtn.onclick = window.$chatwoot.toggle;
+    addClass(closeBtn, 'button transparent compact close-button close-btn');
+    closeBtn.style.visibility = 'hidden';
+
+    widgetHolder.appendChild(closeBtn);
+
     widgetHolder.appendChild(iframe);
     body.appendChild(widgetHolder);
     IFrameHelper.initPostMessageCommunication();
@@ -165,6 +174,9 @@ export const IFrameHelper = {
     const iframe = IFrameHelper.getAppFrame();
     iframe.style.visibility = '';
     iframe.setAttribute('id', `chatwoot_live_chat_widget`);
+
+    const closeBtn = document.getElementById('closeBtn');
+    closeBtn.style.visibility = '';
 
     loadCSS();
     createBubbleHolder();

--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -149,6 +149,7 @@ export const SDK_CSS = `.woot-widget-holder {
   position: absolute;
   top: 20px;
   right: 15px;
+  border: none;
 }
 .close-btn:before, .close-btn:after {
   position: absolute;

--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -144,4 +144,25 @@ export const SDK_CSS = `.woot-widget-holder {
     width: 400px !important;
  }
 }
+
+.close-btn {
+  position: absolute;
+  top: 20px;
+  right: 15px;
+}
+.close-btn:before, .close-btn:after {
+  position: absolute;
+  left: auto;
+  right: auto;
+  content: ' ';
+  height: 16px;
+  width: 2px;
+  background-color: #555;
+}
+.close-btn:before {
+  transform: rotate(45deg);
+}
+.close-btn:after {
+  transform: rotate(-45deg);
+}
 `;

--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -152,6 +152,7 @@ export const SDK_CSS = `.woot-widget-holder {
 }
 .close-btn:before, .close-btn:after {
   position: absolute;
+  top: 7px;
   left: auto;
   right: auto;
   content: ' ';

--- a/app/javascript/widget/components/HeaderActions.vue
+++ b/app/javascript/widget/components/HeaderActions.vue
@@ -7,9 +7,6 @@
     >
       <span class="ion-android-open"></span>
     </button>
-    <button class="button transparent compact close-button">
-      <span class="ion-android-close" @click="closeWindow"></span>
-    </button>
   </div>
 </template>
 <script>


### PR DESCRIPTION
## Description

This PR replaces the close button with a button outside of the iFrame to address the close button not working on IE11.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Checklist:

- [x] tested in safari, chrome, IE 11, firefox, mobile sizes

## Screenshots

https://user-images.githubusercontent.com/27939329/115588086-5df70600-a29c-11eb-9a29-d79ccc23129c.mp4

### BEFORE Styling in IE (note that attachment icon is cut off in current state)
<img width="415" alt="Screen Shot 2021-04-21 at 12 15 34 PM" src="https://user-images.githubusercontent.com/27939329/115588204-7f57f200-a29c-11eb-9d65-e6f96d6d0fc9.png">

### AFTER Styling in chrome
<img width="422" alt="Screen Shot 2021-04-21 at 12 13 46 PM" src="https://user-images.githubusercontent.com/27939329/115595825-63a51980-a2a5-11eb-89a0-3315c29cad8f.png">


