### PR TITLE
fix unread functionality

### DIFF
--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -154,6 +154,9 @@ export const IFrameHelper = {
         onBubbleClick({ toggleValue });
         const holderEl = document.querySelector('.woot-widget-holder');
         addClass(holderEl, 'has-unread-view');
+
+        const closeBtn = document.getElementById('chatwoot_close_btn');
+        closeBtn.style.visibility = 'hidden';
       }
     },
 
@@ -165,6 +168,9 @@ export const IFrameHelper = {
     removeUnreadClass: () => {
       const holderEl = document.querySelector('.woot-widget-holder');
       removeClass(holderEl, 'has-unread-view');
+
+      const closeBtn = document.getElementById('chatwoot_close_btn');
+      closeBtn.style.visibility = '';
     },
   },
   pushEvent: eventName => {

--- a/app/javascript/widget/components/ChatAttachment.vue
+++ b/app/javascript/widget/components/ChatAttachment.vue
@@ -56,6 +56,7 @@ export default {
   cursor: pointer;
   position: relative;
   width: 20px;
+  display: block;
 
   i {
     font-size: $font-size-large;

--- a/app/javascript/widget/views/Unread.vue
+++ b/app/javascript/widget/views/Unread.vue
@@ -99,7 +99,6 @@ export default {
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
-  justify-content: flex-end;
   overflow: hidden;
 
   .unread-messages {


### PR DESCRIPTION
# Pull Request Template

## Description

When chatwoot is closed and user receives a message, the unread UI was not showing up for IE, and we were seeing both close buttons on top of eachother. This PR fixes the styling so the UI shows up, and hides our button when the unread UI is visible.

Somehow the close button on the unread view actually works in IE, where the widget close button doesn't, even though they both seem to do the same thing..


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on IE 11 with browserstack


## Checklist:

- [x] test on mobile views
- [x] test on firefox

# Screenshots 
<img width="350" alt="Screen Shot 2021-04-27 at 1 20 04 PM" src="https://user-images.githubusercontent.com/27939329/116284712-5f707480-a75b-11eb-9fdd-65458097053f.png">
<img width="467" alt="Screen Shot 2021-04-27 at 1 19 43 PM" src="https://user-images.githubusercontent.com/27939329/116284714-60090b00-a75b-11eb-85c3-14a526cfd45c.png">
<img width="350" alt="Screen Shot 2021-04-27 at 1 19 26 PM" src="https://user-images.githubusercontent.com/27939329/116284715-60090b00-a75b-11eb-81cb-d3a5d7fa6d26.png">
<img width="491" alt="Screen Shot 2021-04-27 at 1 17 03 PM" src="https://user-images.githubusercontent.com/27939329/116284716-60090b00-a75b-11eb-952c-c7fa062a8644.png">
<img width="375" alt="Screen Shot 2021-04-27 at 1 15 38 PM" src="https://user-images.githubusercontent.com/27939329/116284717-60090b00-a75b-11eb-949a-4d0708493df1.png">
<img width="487" alt="Screen Shot 2021-04-27 at 1 15 07 PM" src="https://user-images.githubusercontent.com/27939329/116284719-60a1a180-a75b-11eb-97c5-606cfc69c900.png">





<img width="441" alt="Screen Shot 2021-04-27 at 1 23 14 PM" src="https://user-images.githubusercontent.com/27939329/116285050-c130de80-a75b-11eb-8605-e2c5afef9a61.png">
<img width="431" alt="Screen Shot 2021-04-27 at 1 23 00 PM" src="https://user-images.githubusercontent.com/27939329/116285051-c1c97500-a75b-11eb-9f39-b6a47f3345af.png">
