### PR TITLE
Upgrade Dependecies found in `ruby-advisory-db`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,7 @@ GEM
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    oauth (0.5.4)
+    oauth (0.5.6)
     orm_adapter (0.5.0)
     os (1.1.1)
     parallel (1.19.2)
@@ -408,7 +408,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -674,4 +674,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.1.4
+   2.2.16


### PR DESCRIPTION
CI Failed on master with some issues that were found in
`ruby-advisory-db`

Nice and easy to upgrade them tho! The following was generated with
```
bundle update --conservative oath rexml
```