### PR TITLE
show widget on unread

### DIFF
--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -158,13 +158,8 @@ export const IFrameHelper = {
       const toggleValue = true;
 
       if (!isOpen && unreadMessageCount > 0) {
-        IFrameHelper.sendMessage('set-unread-view');
+        IFrameHelper.pushEvent('webwidget.triggered');
         onBubbleClick({ toggleValue });
-        const holderEl = document.querySelector('.woot-widget-holder');
-        addClass(holderEl, 'has-unread-view');
-
-        const closeBtn = document.getElementById('chatwoot_close_btn');
-        closeBtn.style.visibility = 'hidden';
       }
     },
 
@@ -176,9 +171,6 @@ export const IFrameHelper = {
     removeUnreadClass: () => {
       const holderEl = document.querySelector('.woot-widget-holder');
       removeClass(holderEl, 'has-unread-view');
-
-      const closeBtn = document.getElementById('chatwoot_close_btn');
-      closeBtn.style.visibility = '';
     },
   },
   pushEvent: eventName => {


### PR DESCRIPTION
# Pull Request Template

## Description

- [x] merge https://github.com/WellSheet/chatwoot/pull/13 first

Open the widget instead of the unread UI when widget is closed and a new message is received. 


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
Demonstration in IE 11. Page is refreshed to show unread messages are cleared so widget does not auto-open.
https://user-images.githubusercontent.com/27939329/119140101-c65b1380-ba11-11eb-8973-fa5cbcb8011f.mp4

