### PR TITLE
set last seen on agent message received

### DIFF
--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -128,10 +128,10 @@ export default {
     createWidgetEvents(message) {
       const { eventName } = message;
       const isWidgetTriggerEvent = eventName === 'webwidget.triggered';
+      this.setUserLastSeen();
       if (isWidgetTriggerEvent) {
         return;
       }
-      this.setUserLastSeen();
       this.$store.dispatch('events/create', { name: eventName });
     },
     registerListeners() {

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -100,10 +100,8 @@ export default {
     },
     registerUnreadEvents() {
       bus.$on('on-agent-message-recieved', () => {
-        if (!this.isIFrame) {
-          this.setUserLastSeen();
-        }
         this.setUnreadView();
+        this.setUserLastSeen();
       });
       bus.$on('on-unread-view-clicked', () => {
         this.unsetUnreadView();
@@ -130,7 +128,7 @@ export default {
     createWidgetEvents(message) {
       const { eventName } = message;
       const isWidgetTriggerEvent = eventName === 'webwidget.triggered';
-      if (isWidgetTriggerEvent && this.showUnreadView) {
+      if (isWidgetTriggerEvent) {
         return;
       }
       this.setUserLastSeen();


### PR DESCRIPTION
Chatwoot chat is coming up unexpectedly. This PR fixes that by calling `this.setUserLastSeen();` when a new message is received or when the window is closed.

Before this, the chat could be triggered incorrectly as follows: 
a) User opens chat. User receives message from agent. User refreshes page. Chat window appears. 
b) Agent sends message when user has app closed. User opens the app. Chat window appears. User dismisses. User refreshes. Chat window appears.

Unclear whether this addresses the issues we discussed in prod since both depend on the agent sending the user a message.